### PR TITLE
Make disabling of PIC/PIE explicit.

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,8 +1,8 @@
 
 LDFLAGS = $(shell pkg-config --libs glib-2.0) -L/usr/local/lib \
-	  -O3
+	  -O3 -no-pie
 CFLAGS	= $(shell pkg-config --cflags glib-2.0) -I. -I/usr/local/include -Wall \
-	  -O3 -DNDEBUG -fomit-frame-pointer
+	  -O3 -DNDEBUG -fomit-frame-pointer -fno-pic
 CC	= gcc
 LD	= gcc
 


### PR DESCRIPTION
VMs don't work with PIC/PIE enabled in x86-64, since enabling this
prevent the compiler from optimize pointer size to 32bit. This means
that pointers are effectively 64bit in size, and when 32bit pointer
arithmetic is applied, these pointers break.